### PR TITLE
lookup SocketKind with sock.type

### DIFF
--- a/proxyprotocol/server/protocol.py
+++ b/proxyprotocol/server/protocol.py
@@ -185,7 +185,7 @@ class UpstreamProtocol(_Base):
         sock = sock_info.socket
         ssl_object = sock_info.transport.get_extra_info('ssl_object')
         try:
-            protocol: Optional[SocketKind] = SocketKind(sock.proto)
+            protocol: Optional[SocketKind] = SocketKind(sock.type)
         except ValueError:
             protocol = None
         return self.pp.build(sock_info.peername, sock_info.sockname,


### PR DESCRIPTION
Confusingly `sock.proto` is not analogous to the PROXY protocol's socket
protocol, rather the `sock.type` attribute is. In almost all cases
`sock.proto` will be zero as per
https://docs.python.org/3/library/socket.html#socket.socket

This was resulting in the command `proxyprotocol-server --service
localhost:8082 localhost:8080` always injecting a PROXY protocol header
with a protocol of int 0 to the downstream server. This PR fixes that,
it now correctly injects int 1 in the above scenario and the other
`SocketKind` lookups should also work correctly.