### PR TITLE
Fix race condition on upstream header write

### DIFF
--- a/proxyprotocol/server/echo.py
+++ b/proxyprotocol/server/echo.py
@@ -71,6 +71,7 @@ async def run_conn(pp: ProxyProtocol, reader: StreamReader,
                 if not line:
                     break
                 writer.write(line)
+                await writer.drain()
         except IOError:
             pass
         finally:

--- a/proxyprotocol/server/protocol.py
+++ b/proxyprotocol/server/protocol.py
@@ -125,13 +125,12 @@ class DownstreamProtocol(_Base):
             _log.exception('[%s] Connection failed: %s',
                            self.id.hex(), self.upstream)
         else:
-            assert isinstance(upstream, UpstreamProtocol)
-            self._upstream = upstream
-            dnsbl_task.add_done_callback(self._send_initial)
+            callback = partial(self._send_initial, upstream)
+            dnsbl_task.add_done_callback(callback)
 
-    def _send_initial(self, dnsbl_task: Task[Optional[str]]) -> None:
-        upstream = self._upstream
-        assert upstream is not None
+    def _send_initial(self, upstream: UpstreamProtocol,
+                      dnsbl_task: Task[Optional[str]]) -> None:
+        self._upstream = upstream
         upstream.write_header(dnsbl_task.result())
         waiting = self._waiting
         while waiting:

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open('LICENSE.md') as f:
     license = f.read()
 
 setup(name='proxy-protocol',
-      version='0.8.0',
+      version='0.8.1',
       author='Ian Good',
       author_email='ian@icgood.net',
       description='PROXY protocol library with asyncio server implementation',


### PR DESCRIPTION
Data could be proxied upstream before the PROXY protocol header had been written, causing the parsing to throw a syntax error.